### PR TITLE
Test torchaudio RNNTL values against others

### DIFF
--- a/espnet/nets/pytorch_backend/transducer/loss.py
+++ b/espnet/nets/pytorch_backend/transducer/loss.py
@@ -3,6 +3,7 @@
 """Transducer loss module."""
 
 import torch
+from torchaudio.prototype.rnnt_loss import RNNTLoss as TorchaudioLoss
 
 
 class TransLoss(torch.nn.Module):
@@ -74,5 +75,13 @@ class TransLoss(torch.nn.Module):
         else:
             loss = self.trans_loss(pred_pad, target, pred_len, target_len)
         loss = loss.to(dtype=dtype)
+
+        torchaudio_RNNT = TorchaudioLoss(blank=self.blank_id)
+        torchaudio_loss = torchaudio_RNNT(pred_pad, target, pred_len, target_len)
+        torchaudio_loss = torch.mean(torchaudio_loss)
+        
+        abs_diff = abs(loss.item() - torchaudio_loss.item())
+
+        print(f'--> diff {abs_diff}, {self.trans_type} {loss.item()} torchaudio {torchaudio_loss.item()}')
 
         return loss


### PR DESCRIPTION
Test torchaudio RNNTL values against others: 
- difference between warp-transducer and torchaudio is either `9.5367431640625e-07` or `0.0`

<details>
<summary>pytest test/test_e2e_asr_transducer.py</summary>
<pre>
test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic0-recog_dic0] [W LegacyTypeDispatch.h:79] Warning: AutoNonVariableTypeMode is deprecated and will be removed in 1.10 release. For kernel implementations please use AutoDispatchBelowADInplaceOrView instead, If you are looking for a user facing API to enable running your inference-only workload, please use c10::InferenceMode. Using AutoDispatchBelowADInplaceOrView in user code is under risk of producing silent wrong result in some edge cases. See Note [AutoDispatchBelowAutograd] for more details. (function operator())
--> diff 9.5367431640625e-07, warp-transducer 8.667543411254883 torchaudio 8.667542457580566

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic1-recog_dic1] --> diff 0.0, warp-transducer 8.790346145629883 torchaudio 8.790346145629883

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic2-recog_dic2] --> diff 0.0, warp-transducer 8.952201843261719 torchaudio 8.952201843261719

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic3-recog_dic3] --> diff 0.0, warp-transducer 13.163553237915039 torchaudio 13.163553237915039

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic4-recog_dic4] --> diff 9.5367431640625e-07, warp-transducer 13.915616989135742 torchaudio 13.915616035461426

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic5-recog_dic5] --> diff 9.5367431640625e-07, warp-transducer 9.469289779663086 torchaudio 9.469290733337402

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic6-recog_dic6] --> diff 9.5367431640625e-07, warp-transducer 8.74615478515625 torchaudio 8.746153831481934

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic7-recog_dic7] --> diff 0.0, warp-transducer 9.652655601501465 torchaudio 9.652655601501465

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic8-recog_dic8] --> diff 0.0, warp-transducer 9.717862129211426 torchaudio 9.717862129211426

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic9-recog_dic9] --> diff 0.0, warp-transducer 9.725698471069336 torchaudio 9.725698471069336

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic10-recog_dic10] --> diff 0.0, warp-transducer 9.004988670349121 torchaudio 9.004988670349121

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic11-recog_dic11] --> diff 9.5367431640625e-07, warp-transducer 9.09173583984375 torchaudio 9.091734886169434

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic12-recog_dic12] --> diff 0.0, warp-transducer 9.123960494995117 torchaudio 9.123960494995117

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic13-recog_dic13] --> diff 0.0, warp-transducer 9.312193870544434 torchaudio 9.312193870544434

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic14-recog_dic14] --> diff 0.0, warp-transducer 9.049151420593262 torchaudio 9.049151420593262

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic15-recog_dic15] --> diff 0.0, warp-transducer 8.665363311767578 torchaudio 8.665363311767578

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic16-recog_dic16] --> diff 0.0, warp-transducer 9.684125900268555 torchaudio 9.684125900268555

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic17-recog_dic17] --> diff 9.5367431640625e-07, warp-transducer 9.199212074279785 torchaudio 9.199213027954102

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic18-recog_dic18] --> diff 0.0, warp-transducer 9.446760177612305 torchaudio 9.446760177612305

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic19-recog_dic19] --> diff 0.0, warp-transducer 9.30295181274414 torchaudio 9.30295181274414

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic20-recog_dic20] --> diff 0.0, warp-transducer 9.079410552978516 torchaudio 9.079410552978516

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic21-recog_dic21] --> diff 9.5367431640625e-07, warp-transducer 9.20545768737793 torchaudio 9.205458641052246

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic22-recog_dic22] --> diff 0.0, warp-transducer 9.319737434387207 torchaudio 9.319737434387207

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic23-recog_dic23] --> diff 9.5367431640625e-07, warp-transducer 10.8152494430542 torchaudio 10.815250396728516

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic24-recog_dic24] --> diff 9.5367431640625e-07, warp-transducer 10.081360816955566 torchaudio 10.08135986328125

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic25-recog_dic25] --> diff 9.5367431640625e-07, warp-transducer 9.231080055236816 torchaudio 9.231081008911133

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic26-recog_dic26] --> diff 9.5367431640625e-07, warp-transducer 9.591622352600098 torchaudio 9.591621398925781

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic27-recog_dic27] --> diff 0.0, warp-transducer 9.391515731811523 torchaudio 9.391515731811523

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic28-recog_dic28] --> diff 9.5367431640625e-07, warp-transducer 9.560677528381348 torchaudio 9.560676574707031

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic29-recog_dic29] --> diff 9.5367431640625e-07, warp-transducer 8.913601875305176 torchaudio 8.91360092163086

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic30-recog_dic30] --> diff 9.5367431640625e-07, warp-transducer 8.778623580932617 torchaudio 8.7786226272583

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic31-recog_dic31] --> diff 9.5367431640625e-07, warp-transducer 10.217510223388672 torchaudio 10.217509269714355

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic32-recog_dic32] --> diff 4.76837158203125e-07, warp-transducer 7.524420261383057 torchaudio 7.524419784545898

test/test_e2e_asr_transducer.py::test_pytorch_transducer_trainable_and_decodable[train_dic33-recog_dic33] --> diff 9.5367431640625e-07, warp-transducer 11.028676986694336 torchaudio 11.02867603302002

test/test_e2e_asr_transducer.py::test_pytorch_transducer_gpu_trainable[warp-transducer] SKIPPED (gpu re...)
test/test_e2e_asr_transducer.py::test_pytorch_transducer_gpu_trainable[warp-rnnt] SKIPPED (gpu required)
test/test_e2e_asr_transducer.py::test_pytorch_multi_gpu_trainable[train_dic0] SKIPPED (multi gpu required)
test/test_e2e_asr_transducer.py::test_calculate_plot_attention 
test/test_e2e_asr_transducer.py::test_auxiliary_task[train_dic0] --> diff 9.5367431640625e-07, warp-transducer 9.070453643798828 torchaudio 9.070452690124512
--> diff 0.0, warp-transducer 8.918353080749512 torchaudio 8.918353080749512

test/test_e2e_asr_transducer.py::test_auxiliary_task[train_dic1] --> diff 0.0, warp-transducer 8.963645935058594 torchaudio 8.963645935058594

test/test_e2e_asr_transducer.py::test_auxiliary_task[train_dic2] --> diff 0.0, warp-transducer 12.439449310302734 torchaudio 12.439449310302734
--> diff 1.9073486328125e-06, warp-transducer 15.157796859741211 torchaudio 15.157794952392578

test/test_e2e_asr_transducer.py::test_auxiliary_task[train_dic3] --> diff 9.5367431640625e-07, warp-transducer 8.86612319946289 torchaudio 8.866122245788574

test/test_e2e_asr_transducer.py::test_auxiliary_task[train_dic4] --> diff 9.5367431640625e-07, warp-transducer 9.2593355178833 torchaudio 9.259334564208984

test/test_e2e_asr_transducer.py::test_invalid_aux_task_layer_list 
<pre>
</details>